### PR TITLE
rebasing the travis-ci build to new boozerbar/boozer Docker image for…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ script:
 - >
   if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
-    docker push bgulla/boozer
+    docker push boozerbar/boozer
   fi


### PR DESCRIPTION
changing the CI/CD auto-building docker image from `bgulla/boozer` to `boozerbar/boozer`